### PR TITLE
Add option to toggle whether an investment is winning in the admin interface

### DIFF
--- a/app/components/admin/budget_investments/row_component.html.erb
+++ b/app/components/admin/budget_investments/row_component.html.erb
@@ -49,6 +49,10 @@
     <%= render Admin::BudgetInvestments::ToggleSelectionComponent.new(investment) %>
   </td>
 
+  <td data-field="winning">
+    <%= render Admin::BudgetInvestments::ToggleWinningComponent.new(investment) %>
+  </td>
+
   <% if params[:advanced_filters]&.include?("selected") %>
     <td data-field="incompatible">
       <%= investment.incompatible? ? t("shared.yes") : t("shared.no") %>

--- a/app/components/admin/budget_investments/toggle_winning_component.html.erb
+++ b/app/components/admin/budget_investments/toggle_winning_component.html.erb
@@ -1,0 +1,5 @@
+<% if can?(action, investment) %>
+  <%= render Admin::ToggleSwitchComponent.new(action, investment, pressed: winning?, **options) %>
+<% elsif winning? %>
+  <%= t("admin.budget_investments.index.winning") %>
+<% end %>

--- a/app/components/admin/budget_investments/toggle_winning_component.rb
+++ b/app/components/admin/budget_investments/toggle_winning_component.rb
@@ -1,0 +1,46 @@
+class Admin::BudgetInvestments::ToggleWinningComponent < ApplicationComponent
+  attr_reader :investment
+  use_helpers :can?
+  delegate :winning?, to: :investment
+
+  def initialize(investment)
+    @investment = investment
+  end
+
+  private
+
+    def action
+      if winning?
+        :unmark_as_winner
+      else
+        :mark_as_winner
+      end
+    end
+
+    def path
+      url_for({
+        controller: "admin/budget_investments",
+        action: action,
+        budget_id: investment.budget,
+        id: investment,
+        filter: params[:filter],
+        sort_by: params[:sort_by],
+        min_total_supports: params[:min_total_supports],
+        max_total_supports: params[:max_total_supports],
+        advanced_filters: params[:advanced_filters],
+        page: params[:page]
+      })
+    end
+
+    def options
+      {
+        "aria-label": label,
+        form_class: "toggle-winning",
+        path: path
+      }
+    end
+
+    def label
+      t("admin.actions.label", action: t("admin.actions.winning"), name: investment.title)
+    end
+end

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -92,6 +92,26 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
   end
 
+  def mark_as_winner
+    authorize! :mark_as_winner, @investment
+    @investment.update!(winning: true)
+
+    respond_to do |format|
+      format.html { redirect_to request.referer, notice: t("flash.actions.update.budget_investment") }
+      format.js { render :toggle_winning }
+    end
+  end
+
+  def unmark_as_winner
+    authorize! :unmark_as_winner, @investment
+    @investment.update!(winning: false)
+
+    respond_to do |format|
+      format.html { redirect_to request.referer, notice: t("flash.actions.update.budget_investment") }
+      format.js { render :toggle_winning }
+    end
+  end
+
   private
 
     def load_comments
@@ -120,7 +140,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
     def allowed_params
       attributes = [:external_url, :heading_id, :administrator_id, :tag_list,
-                    :valuation_tag_list, :incompatible, :selected,
+                    :valuation_tag_list, :incompatible, :selected, :winning,
                     :milestone_tag_list, valuator_ids: [], valuator_group_ids: []]
       [*attributes, translation_params(Budget::Investment)]
     end

--- a/spec/components/admin/budget_investments/toggle_winning_component_spec.rb
+++ b/spec/components/admin/budget_investments/toggle_winning_component_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Admin::BudgetInvestments::ToggleWinningComponent, type: :component do
+  let(:investment) { create(:budget_investment) }
+
+  before do
+    allow(view).to receive(:can?).and_return(true)
+  end
+
+  it "renders the toggle switch for winning status" do
+    render_inline(described_class.new(investment))
+
+    expect(page).to have_css(".toggle-winning")
+  end
+
+  context "when the investment is winning" do
+    before do
+      investment.update!(winning: true)
+    end
+
+    it "renders the toggle switch as pressed" do
+      render_inline(described_class.new(investment))
+
+      expect(page).to have_css(".toggle-winning[aria-pressed='true']")
+    end
+  end
+
+  context "when the investment is not winning" do
+    before do
+      investment.update!(winning: false)
+    end
+
+    it "renders the toggle switch as not pressed" do
+      render_inline(described_class.new(investment))
+
+      expect(page).to have_css(".toggle-winning[aria-pressed='false']")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DominikPeters/consuldemocracy/pull/2?shareId=d1ab5f9e-f7d7-4f96-b0a7-c5236f669d74).